### PR TITLE
Basic HTTPS smoke test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: "Ubuntu 'chiselled-jre' Tests"
 
-on: push
+on:
+  pull_request:
+  push:
 
 env:
   image-name: ubuntu/chiselled-jre:test
@@ -21,7 +23,7 @@ jobs:
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '8'
-          
+
       - name: Build the chiselled-jre image
         run: |
           docker build \

--- a/tests/https-test/runtest
+++ b/tests/https-test/runtest
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+echo "Running test for Java Hello World app"
+
+compile src/Main.java "-d ."
+
+run_container $BASE_IMAGE Main

--- a/tests/https-test/runtest
+++ b/tests/https-test/runtest
@@ -5,4 +5,4 @@ echo "Running test for Java Hello World app"
 
 compile src/Main.java "-d ."
 
-run_container $BASE_IMAGE Main
+run_container $BASE_IMAGE "-Djavax.net.debug=all Main"

--- a/tests/https-test/src/Main.java
+++ b/tests/https-test/src/Main.java
@@ -1,0 +1,22 @@
+import java.net.URL;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+public class Main {
+    /**
+     *   Connects to github and reads the front page.
+     *   This test should not throw
+     */
+    public static void main(String[] args) throws IOException {
+        URL url = new URL("https://github.com");
+        InputStream stream = url.openStream();
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(stream));
+        while (reader.readLine()!=null){
+        }
+
+    }
+}

--- a/tests/https-test/src/Main.java
+++ b/tests/https-test/src/Main.java
@@ -17,6 +17,5 @@ public class Main {
             new BufferedReader(new InputStreamReader(stream));
         while (reader.readLine()!=null){
         }
-
     }
 }


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - adds a basic https smoke test that connects to GitHub and retrieves data. 
   Note: this test will fail with the current version of the image as it is missing 
   ``jre/lib/security/java.policy`` and ``jre/lib/security/java.policy``
   Slices need to be updated. I have ran the test with these additions to the docker
```
COPY java.policy /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/
COPY java.security /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/
```

- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
