### PR TITLE
Split args into several lines to be compatible with podman

### DIFF
--- a/chiselled-jre/Dockerfile.22.04
+++ b/chiselled-jre/Dockerfile.22.04
@@ -1,5 +1,8 @@
 ARG UBUNTU_RELEASE=22.04
-ARG USER=app UID=101 GROUP=app GID=101
+ARG USER=app
+ARG UID=101
+ARG GROUP=app
+ARG GID=101
 
 FROM golang:1.18 AS chisel
 ARG UBUNTU_RELEASE
@@ -21,21 +24,26 @@ COPY --from=chisel /opt/chisel/chisel /usr/bin/
 ### BOILERPLATE END ###
 
 FROM builder AS sliced-deps
-ARG USER UID GROUP GID
+ARG USER
+ARG UID
+ARG GROUP
+ARG GID
 COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
 RUN mkdir -p /rootfs \
     && chisel cut --release /opt/chisel-releases --root /rootfs \
         openjdk-8-jre-headless_bins \
         media-types_data \
         libglib2.0-0_libs \
-        libjpeg-turbo8_libs 
+        libjpeg-turbo8_libs
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 COPY --from=builder /etc/ssl/certs/java/cacerts /rootfs/etc/ssl/certs/java/cacerts
 
 FROM scratch
-ARG USER UID GID
+ARG USER
+ARG UID
+ARG GID
 USER $UID:$GID
 COPY --from=sliced-deps /rootfs /
 # Workaround for https://github.com/moby/moby/issues/38710


### PR DESCRIPTION
Fixes #17 17

#### Changes proposed in this pull request:
 - split args into several lines to keep podman happy
 - remove trailing whitespace


- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
