### PR TITLE
Reduce logging for successful tests

### DIFF
--- a/tests/https-test/runtest
+++ b/tests/https-test/runtest
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -ex
 
-echo "Running test for Java Hello World app"
+echo "Running test for HTTPS connection app"
 
 compile src/Main.java "-d ."
 
-run_container $BASE_IMAGE "-Djavax.net.debug=all Main"
+# run the test and if it fails, retry with the full network diagnostics
+run_container $BASE_IMAGE Main || \
+    run_container $BASE_IMAGE "-Djavax.net.debug=all Main"


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - Update echo statement at the start of the test
 - Run test without diagnostics by default, the failure should be very rare (image completely broken, or github not reachable)


- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
