### PR TITLE
Use runner user uid:gid inside dockers to share maven cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   image-name: ubuntu/chiselled-jre:test
-  build-image-name: ubuntu/chiselled-jre:test-builder
+  build-image-name: temurin-jdk8-builder:test
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   image-name: ubuntu/chiselled-jre:test
+  build-image-name: ubuntu/chiselled-jre:test-builder
 
 jobs:
   build:
@@ -27,25 +28,56 @@ jobs:
       - name: Tests Maven cache
         uses: actions/cache@v3
         with:
-          path: |
-            tests/petclinic-test/.m2
-            tests/pdfbox/.m2
+          path: ${{ runner.temp }}/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+
+      - name: Tests PDFBox
+        uses: actions/cache@v3
+        with:
+          path: tests/pdfbox/pdfbox-2.0.27
+          key: tests-pdfbox-pdfbox-2.0.27
+          restore-keys: |
+            tests-pdfbox-pdfbox-2.0.27
+
+      - name: Tests Petclinic
+        uses: actions/cache@v3
+        with:
+          path: tests/petclinic-test/spring-petclinic
+          key: tests-petclinic-test-spring-petclinic
+          restore-keys: |
+            tests-petclinic-test-spring-petclinic
 
       - name: Build the chiselled-jre image
         run: |
           docker build \
           -t ${{ env.image-name }} \
+          --build-arg UID=$(id -u ${USER}) \
+          --build-arg GID=$(id -g ${USER}) \
           -f chiselled-jre/Dockerfile.${{ matrix.ubuntu-release }} \
           chiselled-jre
+
+      - name: Build the JDK docker image
+        run: |
+          echo $USER
+          id -u $USER
+          id -g $USER
+
+          docker build \
+          -t ${{ env.build-image-name }} \
+          --build-arg UID=$(id -u ${USER}) \
+          --build-arg GID=$(id -g ${USER}) \
+          -f tests/Dockerfile.${{ matrix.ubuntu-release }} \
+          tests
 
       - name: Run Tests
         working-directory: ${{ github.workspace }}/tests/
         run: |
-          ./run-all-tests ${{ env.image-name }}
-
+          mkdir -p ${{ runner.temp }}/.m2
+          ./run-all-tests ${{ env.image-name }} \
+                          ${{ env.build-image-name }} \
+                          ${{ runner.temp }}/.m2
   multi-arch-build:
     runs-on: ubuntu-22.04
     name: Multi Architecture Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,10 +60,6 @@ jobs:
 
       - name: Build the JDK docker image
         run: |
-          echo $USER
-          id -u $USER
-          id -g $USER
-
           docker build \
           -t ${{ env.build-image-name }} \
           --build-arg UID=$(id -u ${USER}) \
@@ -74,7 +70,6 @@ jobs:
       - name: Run Tests
         working-directory: ${{ github.workspace }}/tests/
         run: |
-          mkdir -p ${{ runner.temp }}/.m2
           ./run-all-tests ${{ env.image-name }} \
                           ${{ env.build-image-name }} \
                           ${{ runner.temp }}/.m2

--- a/tests/Dockerfile.22.04
+++ b/tests/Dockerfile.22.04
@@ -1,0 +1,18 @@
+ARG BUILD_IMAGE=eclipse-temurin:8u362-b09-jdk-jammy
+ARG USER=app
+ARG UID=101
+ARG GROUP=app
+ARG GID=101
+
+FROM ${BUILD_IMAGE}
+
+ARG USER
+ARG UID
+ARG GROUP
+ARG GID
+
+RUN install -d -m 0755 -o $UID -g $GID /home/$USER \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/etc/passwd
+
+USER $UID:$GID

--- a/tests/pdfbox/Dockerfile
+++ b/tests/pdfbox/Dockerfile
@@ -1,18 +1,9 @@
 ARG BASE_IMAGE=ubuntu/chiselled-jre:8_edge
 ARG MAVEN_IMAGE=maven:3.9.0-eclipse-temurin-8
-ARG USER=app
-ARG UID=101
-ARG GROUP=app
-ARG GID=101
-
 FROM $MAVEN_IMAGE as builder
 
 FROM $BASE_IMAGE
 
-ARG USER
-ARG UID
-ARG GID
-USER $UID:$GID
 COPY --from=builder /bin/sh /bin/sh
 COPY --from=builder /usr/bin/chmod /usr/bin/chmod
 COPY --from=builder /usr/bin/uname /usr/bin/uname

--- a/tests/pdfbox/runtest
+++ b/tests/pdfbox/runtest
@@ -26,7 +26,7 @@ VERSION=2.0.27
 APP=pdfbox-${VERSION}
 TEST_DIR=`pwd`
 
-DOCKER_OPTIONS="--rm  \
+DOCKER_OPTS="--rm  \
     --tmpfs /tmp:exec \
     -u app \
     -v ${M2_CACHE}:${M2_CACHE} \
@@ -46,7 +46,7 @@ docker build -t chiselled-maven \
 
 # build and tests with chiselled jre
 docker run \
-    ${DOCKER_OPTIONS} \
+    ${DOCKER_OPTS} \
     chiselled-maven \
         -Dmaven.repo.local="${M2_CACHE}" \
         test

--- a/tests/pdfbox/runtest
+++ b/tests/pdfbox/runtest
@@ -2,11 +2,36 @@
 
 set -ex
 
+# This tests downloads PDFBox, patches out flaky test, copies javac in the
+# container and then builds and runs PDFBox tests
+echo "Running Apache PDFBox self-tests"
+
+if [ -z $BUILD_IMAGE ]; then
+    echo 'Please define $BUILD_IMAGE'
+    exit 1
+fi
+
+if [ -z $BASE_IMAGE ]; then
+    echo 'Please define $BASE_IMAGE'
+    exit 1
+fi
+
+if [ -z $M2_CACHE ]; then
+    echo 'Please define $M2_CACHE'
+    exit 1
+fi
+
+MAVEN_IMAGE=maven:3.9.0-eclipse-temurin-8
 VERSION=2.0.27
 APP=pdfbox-${VERSION}
-MAVEN_IMAGE=maven:3.9.0-eclipse-temurin-8
 TEST_DIR=`pwd`
-M2_CACHE=${1:-"/tmp/.m2"}
+
+DOCKER_OPTIONS="--rm  \
+    --tmpfs /tmp:exec \
+    -u app \
+    -v ${M2_CACHE}:${M2_CACHE} \
+    -v ${TEST_DIR}:${TEST_DIR} \
+    -w ${TEST_DIR}/${APP} "
 
 if [ ! -d ${APP} ]; then
     curl -o ${APP}-src.zip  https://dlcdn.apache.org/pdfbox/${VERSION}/${APP}-src.zip
@@ -20,13 +45,8 @@ docker build -t chiselled-maven \
     .
 
 # build and tests with chiselled jre
-docker run --rm  \
-    --tmpfs /tmp:exec \
-    -u app \
-    -v ${M2_CACHE}:${M2_CACHE}:rw \
-    -v ${TEST_DIR}:${TEST_DIR} \
-    -w ${TEST_DIR}/${APP} \
+docker run \
+    ${DOCKER_OPTIONS} \
     chiselled-maven \
         -Dmaven.repo.local="${M2_CACHE}" \
-        -Dmaven.compiler.useIncrementalCompilation=false \
         test

--- a/tests/pdfbox/runtest
+++ b/tests/pdfbox/runtest
@@ -6,6 +6,7 @@ VERSION=2.0.27
 APP=pdfbox-${VERSION}
 MAVEN_IMAGE=maven:3.9.0-eclipse-temurin-8
 TEST_DIR=`pwd`
+M2_CACHE=${1:-"/tmp/.m2"}
 
 if [ ! -d ${APP} ]; then
     curl -o ${APP}-src.zip  https://dlcdn.apache.org/pdfbox/${VERSION}/${APP}-src.zip
@@ -21,10 +22,11 @@ docker build -t chiselled-maven \
 # build and tests with chiselled jre
 docker run --rm  \
     --tmpfs /tmp:exec \
-    -u $(id -u ${USER}):$(id -g ${USER}) \
+    -u app \
+    -v ${M2_CACHE}:${M2_CACHE}:rw \
     -v ${TEST_DIR}:${TEST_DIR} \
     -w ${TEST_DIR}/${APP} \
     chiselled-maven \
-        -Dmaven.repo.local="${TEST_DIR}/.m2" \
+        -Dmaven.repo.local="${M2_CACHE}" \
         -Dmaven.compiler.useIncrementalCompilation=false \
         test

--- a/tests/petclinic-test/Dockerfile
+++ b/tests/petclinic-test/Dockerfile
@@ -12,9 +12,5 @@ ARG GID
 USER $UID:$GID
 
 # shell is needed for maven surefire plugin
-ADD --chown=$UID:$GID sh /bin/sh
-ADD --chown=$UID:$GID spring-petclinic /spring-petclinic
-ADD --chown=$UID:$GID .m2 /.m2
-
-WORKDIR /spring-petclinic
+ADD sh /bin/sh
 

--- a/tests/petclinic-test/Dockerfile
+++ b/tests/petclinic-test/Dockerfile
@@ -1,16 +1,5 @@
 ARG BASE_IMAGE=ubuntu/chiselled-jre:8_edge
-ARG USER=app
-ARG UID=101
-ARG GROUP=app
-ARG GID=101
-
 FROM $BASE_IMAGE
-
-ARG USER
-ARG UID
-ARG GID
-USER $UID:$GID
-
 # shell is needed for maven surefire plugin
 ADD sh /bin/sh
 

--- a/tests/petclinic-test/runtest
+++ b/tests/petclinic-test/runtest
@@ -53,7 +53,7 @@ DOCKER_OPTS="--rm --tmpfs /tmp:exec \
 # add shell to allow maven tests
 cp /bin/sh sh
 docker build --build-arg BASE_IMAGE=${BASE_IMAGE:-ubuntu/chiselled-jre:8_edge} \
-    -t petclinic .
+    -t ${PETCLINIC_TAG} .
 
 # Build and run tests with JDK8 container. We should replace Temurin with
 # our dev container
@@ -62,11 +62,11 @@ docker run \
     ${BUILD_IMAGE} \
     java \
     ${MAVEN_COMMAND} \
-    -q test
+    -q test-compile
 
 # now run the tests within our container
 docker run \
     ${DOCKER_OPTS} \
-    petclinic \
+    ${PETCLINIC_TAG} \
     ${MAVEN_COMMAND} \
     test

--- a/tests/petclinic-test/runtest
+++ b/tests/petclinic-test/runtest
@@ -22,13 +22,17 @@ git clone --branch $PETCLINIC_TAG $PETCLINIC_REPO || \
 
 TEST_DIR=`pwd`
 PROJECT_DIR=${TEST_DIR}/spring-petclinic
+M2_CACHE=${1:-"/tmp/.m2"}
 
 # Build and run tests with JDK8 container. We should replace Temurin with
 # our dev container
-docker run -v ${TEST_DIR}:${TEST_DIR} -w ${TEST_DIR}/spring-petclinic \
+docker run \
+    -v ${M2_CACHE}:${M2_CACHE} \
+    -v ${TEST_DIR}:${TEST_DIR} \
+    -w ${TEST_DIR}/spring-petclinic \
     $BUILD_DOCKER \
     java -classpath "${PROJECT_DIR}/.mvn/wrapper/maven-wrapper.jar" \
-         -Dmaven.repo.local="${TEST_DIR}/.m2" \
+         -Dmaven.repo.local="${M2_CACHE}" \
          -Dmaven.multiModuleProjectDirectory="${PROJECT_DIR}" \
          org.apache.maven.wrapper.MavenWrapperMain \
          -q \
@@ -41,9 +45,9 @@ docker build --build-arg BASE_IMAGE=${BASE_IMAGE:-ubuntu/chiselled-jre:8_edge} \
     -t petclinic .
 
 # now run the tests within our container
-docker run --rm --tmpfs /tmp:exec petclinic \
+docker run --rm --tmpfs /tmp:exec -v ${M2_CACHE}:${M2_CACHE} petclinic \
     -classpath /spring-petclinic/.mvn/wrapper/maven-wrapper.jar \
-    -Dmaven.repo.local=/.m2 \
+    -Dmaven.repo.local="${M2_CACHE}" \
     -Dmaven.multiModuleProjectDirectory=/spring-petclinic \
     -Dmaven.compiler.useIncrementalCompilation=false \
     org.apache.maven.wrapper.MavenWrapperMain \

--- a/tests/petclinic-test/runtest
+++ b/tests/petclinic-test/runtest
@@ -8,47 +8,65 @@ set -ex
 
 echo "Running Spring Petclinic self-tests"
 
-# Replace with our development docker when it is ready
-BUILD_DOCKER=eclipse-temurin:8u362-b09-jdk-jammy
+if [ -z $BUILD_IMAGE ]; then
+    echo 'Please define $BUILD_IMAGE'
+    exit 1
+fi
+
+if [ -z $BASE_IMAGE ]; then
+    echo 'Please define $BASE_IMAGE'
+    exit 1
+fi
+
+if [ -z $M2_CACHE ]; then
+    echo 'Please define $M2_CACHE'
+    exit 1
+fi
 
 # clone petclinic repository, alternative is to have a submodule here
+TEST_DIR=`pwd`
+PROJECT=spring-petclinic
+PROJECT_DIR=${TEST_DIR}/${PROJECT}
+
 PETCLINIC_TAG=spring-boot-2.7.3
-PETCLINIC_REPO=https://github.com/vpa1977/spring-petclinic
+PETCLINIC_REPO=https://github.com/vpa1977/${PROJECT}
 echo cloning $PETCLINIC_TAG $PETCLINIC_REPO
 git clone --branch $PETCLINIC_TAG $PETCLINIC_REPO || \
-    (cd spring-petclinic && \
-     git checkout $PETCLINIC_TAG &&
+    (cd ${PROJECT} && \
+     git checkout ${PETCLINIC_TAG} &&
      git reset --hard)
 
-TEST_DIR=`pwd`
-PROJECT_DIR=${TEST_DIR}/spring-petclinic
-M2_CACHE=${1:-"/tmp/.m2"}
+WRAPPER_JAR=${PROJECT_DIR}/.mvn/wrapper/maven-wrapper.jar
+MAVEN_COMMAND="-classpath ${WRAPPER_JAR} \
+                  -Dmaven.home=${M2_CACHE}
+                  -Dmaven.repo.local=${M2_CACHE} \
+                  -Dmaven.repo.local=${M2_CACHE} \
+                  -Dmaven.multiModuleProjectDirectory=${PROJECT_DIR} \
+                  org.apache.maven.wrapper.MavenWrapperMain"
+
+DOCKER_OPTS="--rm --tmpfs /tmp:exec \
+    -v ${M2_CACHE}:${M2_CACHE} \
+    -v ${TEST_DIR}:${TEST_DIR} \
+    -w ${TEST_DIR}/spring-petclinic\
+    -u app"
+
+# add shell to allow maven tests
+cp /bin/sh sh
+docker build --build-arg BASE_IMAGE=${BASE_IMAGE:-ubuntu/chiselled-jre:8_edge} \
+    -t petclinic .
 
 # Build and run tests with JDK8 container. We should replace Temurin with
 # our dev container
 docker run \
-    -v ${M2_CACHE}:${M2_CACHE} \
-    -v ${TEST_DIR}:${TEST_DIR} \
-    -w ${TEST_DIR}/spring-petclinic \
-    $BUILD_DOCKER \
-    java -classpath "${PROJECT_DIR}/.mvn/wrapper/maven-wrapper.jar" \
-         -Dmaven.repo.local="${M2_CACHE}" \
-         -Dmaven.multiModuleProjectDirectory="${PROJECT_DIR}" \
-         org.apache.maven.wrapper.MavenWrapperMain \
-         -q \
-         test
-
-cp /bin/sh sh
-
-# build docker containing maven cache and a project
-docker build --build-arg BASE_IMAGE=${BASE_IMAGE:-ubuntu/chiselled-jre:8_edge} \
-    -t petclinic .
+    ${DOCKER_OPTS} \
+    ${BUILD_IMAGE} \
+    java \
+    ${MAVEN_COMMAND} \
+    -q test
 
 # now run the tests within our container
-docker run --rm --tmpfs /tmp:exec -v ${M2_CACHE}:${M2_CACHE} petclinic \
-    -classpath /spring-petclinic/.mvn/wrapper/maven-wrapper.jar \
-    -Dmaven.repo.local="${M2_CACHE}" \
-    -Dmaven.multiModuleProjectDirectory=/spring-petclinic \
-    -Dmaven.compiler.useIncrementalCompilation=false \
-    org.apache.maven.wrapper.MavenWrapperMain \
+docker run \
+    ${DOCKER_OPTS} \
+    petclinic \
+    ${MAVEN_COMMAND} \
     test

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -18,6 +18,8 @@ run_container() {
 export -f compile
 export -f run_container
 
+mkdir -p ${M2_CACHE}
+
 CURRENT_DIR="$(dirname $(readlink -f $0))"
 
 for test_dir in "$CURRENT_DIR"/*/

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -4,6 +4,8 @@ set -ex
 echo "Running tests..."
 
 export BASE_IMAGE=${1:-"ubuntu/chiselled-jre:test"}
+export BUILD_IMAGE=${2:-"ubuntu/chiselled-jre:test-builder"}
+export M2_CACHE=${3:-"/tmp/.m2"}
 
 compile() {
 	javac -source 8 -target 8 $1 $2


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - Build test docker images with the runner uid:gid
 - Use shared maven cache for tests
 - Cache sample applications
 - Refactor `runtest` scripts
 - Remove user parameters from docker images in specific tests


- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
