### PR TITLE
fix: add .dockerignore to test build image

### DIFF
--- a/tests/.dockerignore
+++ b/tests/.dockerignore
@@ -1,0 +1,3 @@
+*test*
+pdfbox
+app_hello-world


### PR DESCRIPTION
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/21.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/22.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/23.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/24.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/25.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/26.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/27.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/28.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/29.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/30.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/31.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/32.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/33.
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/34.

#### Changes proposed in this pull request:
 - add .dockerignore file in `tests` folder


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
