### PR TITLE
Use more frequently updated Ubuntu image from ECR

### DIFF
--- a/chiselled-jre/Dockerfile.22.04
+++ b/chiselled-jre/Dockerfile.22.04
@@ -12,7 +12,7 @@ WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \
     && go build ./cmd/chisel
 
-FROM ubuntu:$UBUNTU_RELEASE AS builder
+FROM public.ecr.aws/ubuntu/ubuntu:$UBUNTU_RELEASE@sha256:234afeb5d15478d2f8066f3610211fa641c0cd9b551e4ecc64ca93a05c1df5cf AS builder
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \


### PR DESCRIPTION
Related to https://github.com/ubuntu-rocks/chiselled-jre/issues/44.

#### Changes proposed in this pull request:
 - the official images from Docker Hub are uploaded by Docker themselves and thus are not as up to date as the other we publish elsewhere (ECR, ACR). Let's use the Ubuntu image from ECR instead


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
