### PR TITLE
Add "renovate" to automatically bump the Ubuntu bases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "prHourlyLimit": 0,
+  "ignorePaths": [
+    "tests/*", 
+    "demos/*",
+    "benchmarks/*"
+  ],
+  "packageRules": [
+    {
+      "description": "Group relevant Dockerfiles that are used for the Chiselled images",
+      "matchPaths": ["chiselled-jre/Dockerfile*"],
+      "groupName": "Dockerfiles of Chiselled images",
+      "enabled": true,
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "pinDigest"
+      ]
+    }
+  ],
+  "baseBranches": [
+    "/^channels\\/.*/"
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/ubuntu-rocks/chiselled-jre/issues/44.
Related to https://github.com/ubuntu-rocks/chiselled-jre/pull/45.
Blocked by https://github.com/ubuntu-rocks/chiselled-jre/pull/47

#### Changes proposed in this pull request:
 - Use `renovate` to pinDigests so that the base Ubuntu images can be updated upon changes from upstream, thus triggering new builds of this image


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
