### PR TITLE
Typo in standalone-chisel variant of docker compose

### DIFF
--- a/benchmark/docker-compose.standalone-chisel.yml
+++ b/benchmark/docker-compose.standalone-chisel.yml
@@ -9,8 +9,8 @@ services:
       - acme
 
   tomcat:
-    container_name: acmeair-standalone-temurin
-    image: acmeair-standalone-temurin
+    container_name: acmeair-standalone-chisel
+    image: acmeair-standalone-chisel
     networks:
       - acme
     ports:


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - standalone chisel docker-compose had a typo - it instantiated temurin standalone image.
I've reran benchmarks, getting same values again (since it is essentially same JRE running on the same stack)

- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
