### PR TITLE
Use tomcat 9 as a base

### DIFF
--- a/benchmark/acmeair-tomcat/Dockerfile
+++ b/benchmark/acmeair-tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:10.0.27-jre8-temurin-jammy
+FROM tomcat:9.0.72-jre8-temurin-jammy
 
 ADD config/server.xml /usr/local/tomcat/conf/server.xml
 ADD acmeair-java-2.0.0-SNAPSHOT.war /usr/local/tomcat/webapps


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - Use tomcat 9 as a base, since we use Spring Boot 2.X and Tomcat 10 is incompatible with it


- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
