### PR TITLE
acmeair:use tag with fixed mongodb test race condition

### DIFF
--- a/tests/acmeair/runtest
+++ b/tests/acmeair/runtest
@@ -17,7 +17,7 @@ fi
 
 TEST_DIR=`pwd`
 PROJECT=acmeair-monolithic-java
-TAG=chiselled-test
+TAG=chiselled-test-mongo
 ACMEAIR_REPO=https://github.com/vpa1977/${PROJECT}
 
 DOCKER_OPTS="--rm  \


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - acmeair application basic test started embedded mongodb server but did not check that it actually started. It caused intermittent test failures.
 - CI occasionally reset connection to db during DB load causing test failures. Added retries.
  
  This merge request updates test tag to include the fixed version.
 See:
 - https://github.com/vpa1977/acmeair-monolithic-java/commit/51b01ab6496ec9af6bd02dd2a63ddef3e0a7cb53
 - https://github.com/vpa1977/acmeair-monolithic-java/commit/9e440f13e3e99f764913c4db379f58fa046d06c1
 - https://github.com/vpa1977/acmeair-monolithic-java/commit/e11cadfc703ed9010e81932c085bb0e4a6593d64
 - https://github.com/vpa1977/acmeair-monolithic-java/commit/0de4bbd7ec3ca168293d26f58b2290107facd6aa
 
- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
