### PR TITLE
Use main branch for slices

### DIFF
--- a/chiselled-jre/Dockerfile.22.04
+++ b/chiselled-jre/Dockerfile.22.04
@@ -6,7 +6,7 @@ ARG GID=101
 
 FROM golang:1.18 AS chisel
 ARG UBUNTU_RELEASE
-RUN git clone -b jre8-jammy-slices https://github.com/cjdcordeiro/chisel-releases /opt/chisel-releases \
+RUN git clone https://github.com/canonical/chisel-releases /opt/chisel-releases \
     && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \

--- a/tests/pdfbox/Dockerfile
+++ b/tests/pdfbox/Dockerfile
@@ -7,7 +7,7 @@ ARG GID=101
 
 FROM golang:1.18 AS chisel
 ARG UBUNTU_RELEASE
-RUN git clone -b jre8-jammy-slices https://github.com/cjdcordeiro/chisel-releases /opt/chisel-releases \
+RUN git clone https://github.com/canonical/chisel-releases /opt/chisel-releases \
     && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
 WORKDIR /opt/chisel
 RUN go generate internal/deb/version.go \


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - Use main branch of canonical/chisel-releases as jre8 slice branch is merged in the repository


- [*] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----

*Picture of a cool ROCK:*
