### PR TITLE
refactor(java8): simplify build recipe

### DIFF
--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -4,34 +4,22 @@ ARG UID=101
 ARG GROUP=app
 ARG GID=101
 
-FROM golang:1.20 AS chisel
-ARG UBUNTU_RELEASE
-RUN git clone https://github.com/canonical/chisel-releases /opt/chisel-releases \
-    && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
 FROM public.ecr.aws/ubuntu/ubuntu:$UBUNTU_RELEASE@sha256:c6871ae8b54fb3ed0ba4df4eb98527e9a6692088fe0c2f2260a9334853092b47 AS builder
+ARG USER
+ARG UID
+ARG GROUP
+ARG GID
+ARG TARGETARCH
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+ADD https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
         ca-certificates-java \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-
-### BOILERPLATE END ###
-
-FROM builder AS sliced-deps
-ARG USER
-ARG UID
-ARG GROUP
-ARG GID
-SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
-COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
 RUN mkdir -p /rootfs \
-      && chisel cut --release /opt/chisel-releases --root /rootfs \
+      && chisel cut --root /rootfs \
         openjdk-8-jre-headless_core \
         openjdk-8-jre-headless_locale \
         openjdk-8-jre-headless_security \
@@ -48,14 +36,14 @@ RUN mkdir -p /rootfs \
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
-COPY --from=builder /etc/ssl/certs/java/cacerts /rootfs/etc/ssl/certs/java/cacerts
+RUN cp /etc/ssl/certs/java/cacerts /rootfs/etc/ssl/certs/java/cacerts
 
 FROM scratch
 ARG USER
 ARG UID
 ARG GID
 USER $UID:$GID
-COPY --from=sliced-deps /rootfs /
+COPY --from=builder /rootfs /
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown=$UID:$GID /rootfs/home/$USER /home/$USER
 ENTRYPOINT ["/usr/bin/java"]


### PR DESCRIPTION
Download v0.8.0 chisel binary from GitHub release instead of building it. Additionally, do not download chisel-releases initially, chisel will fetch it as needed.

Merge a few stages to simplify the Dockerfile.
