### PR TITLE
refactor(java17): simplify build recipe

### DIFF
--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -4,16 +4,15 @@ ARG UID=101
 ARG GROUP=app
 ARG GID=101
 
-FROM golang:1.20 AS chisel
-ARG UBUNTU_RELEASE
-RUN git clone  --depth 1 -b ubuntu-22.04 https://github.com/canonical/chisel-releases /opt/chisel-releases \
-    && git clone --depth 1 -b main https://github.com/canonical/chisel /opt/chisel
-WORKDIR /opt/chisel
-RUN go generate internal/deb/version.go \
-    && go build ./cmd/chisel
-
 FROM public.ecr.aws/ubuntu/ubuntu:$UBUNTU_RELEASE@sha256:c6871ae8b54fb3ed0ba4df4eb98527e9a6692088fe0c2f2260a9334853092b47 AS builder
+ARG USER
+ARG UID
+ARG GROUP
+ARG GID
+ARG TARGETARCH
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+ADD https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
         ca-certificates-java \
@@ -21,9 +20,6 @@ RUN apt-get update \
         openjdk-17-jdk \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=chisel /opt/chisel/chisel /usr/bin/
-
-### BOILERPLATE END ###
 
 RUN jlink --no-header-files --no-man-pages --strip-debug \
     --add-modules \
@@ -45,15 +41,8 @@ jdk.jdwp.agent \
 WORKDIR /opt/java
 RUN tar zcvf legal.tar.gz legal && rm -r legal
 
-FROM builder AS sliced-deps
-ARG USER
-ARG UID
-ARG GROUP
-ARG GID
-SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
-COPY --from=chisel /opt/chisel-releases /opt/chisel-releases
 RUN mkdir -p /rootfs \
-    && chisel cut --release /opt/chisel-releases --root /rootfs \
+    && chisel cut --root /rootfs \
         libc6_libs \
         libgcc-s1_libs \
         libstdc++6_libs \
@@ -65,15 +54,16 @@ RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && mkdir -p /rootfs/etc \
     && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
     && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
-COPY --from=builder /opt/java/ /rootfs/opt/java/
+RUN mkdir -p /rootfs/opt \
+    && cp -r /opt/java/ /rootfs/opt/java/
 
 FROM scratch
 ARG USER
 ARG UID
 ARG GID
 USER $UID:$GID
-COPY --from=sliced-deps /rootfs /
+COPY --from=builder /rootfs /
 # Workaround for https://github.com/moby/moby/issues/38710
-COPY --from=sliced-deps --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+COPY --from=builder --chown=$UID:$GID /rootfs/home/$USER /home/$USER
 ENV JAVA_HOME /opt/java/
 ENTRYPOINT ["/opt/java/bin/java"]


### PR DESCRIPTION
Download v0.8.0 chisel binary from GitHub release instead of building it. Additionally, do not download chisel-releases initially, chisel will fetch it as needed.

Merge a few stages to simplify the Dockerfile.