### PR TITLE
refactor(17): add CHISEL_VERSION build arg

### DIFF
--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -3,6 +3,7 @@ ARG USER=app
 ARG UID=101
 ARG GROUP=app
 ARG GID=101
+ARG CHISEL_VERSION=0.8.1
 
 FROM public.ecr.aws/ubuntu/ubuntu:$UBUNTU_RELEASE@sha256:c88265b8f9e40ca21547aeecd90b688a167738fefda07b943cdf48f7d714d503 AS builder
 ARG USER
@@ -10,8 +11,9 @@ ARG UID
 ARG GROUP
 ARG GID
 ARG TARGETARCH
+ARG CHISEL_VERSION
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
-ADD https://github.com/canonical/chisel/releases/download/v0.8.1/chisel_v0.8.1_linux_${TARGETARCH}.tar.gz chisel.tar.gz
+ADD https://github.com/canonical/chisel/releases/download/v${CHISEL_VERSION}/chisel_v${CHISEL_VERSION}_linux_${TARGETARCH}.tar.gz chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \


### PR DESCRIPTION
This PR introduces a build argument `CHISEL_VERSION` to track and use proper/updated [chisel](https://github.com/ubuntu-rocks/dotnet/pull/github.com/canonical/chisel) version.