### PR TITLE
Use Renovate to auto-upgrade Chisel version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,18 @@
   ],
   "baseBranches": [
     "/^channels\\/.*/"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
+      ],
+      "matchStrings": ["ARG CHISEL_VERSION=(?<currentValue>.*?)\\s"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "canonical/chisel",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
This PR adds changes to make renovate track chisel updates and add a PR whenever a new version is available. Renovate reference: https://docs.renovatebot.com/modules/manager/regex/.

Similar to https://github.com/canonical/chiselled-python/pull/12.

(ROCKS-932)