### PR TITLE
feat: add java link in /usr/bin

### DIFF
--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -59,6 +59,9 @@ RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
 RUN mkdir -p /rootfs/opt \
     && cp -r /opt/java/ /rootfs/opt/java/
 
+WORKDIR /rootfs
+RUN ln -s --relative opt/java/bin/java usr/bin/
+
 FROM scratch
 ARG USER
 ARG UID


### PR DESCRIPTION
#### Changes proposed in this pull request:
 - add link to java - `/usr/bin/java `

This is done to align Java 8 and 17 containers - both should be able to launch java from /usr/bin
```
docker run --entrypoint=/usr/bin/java jre 
Usage: java [options] <mainclass> [args...]
           (to execute a class)
   or  java [options] -jar <jarfile> [args...]
           (to execute a jar file)
   or  java [options] -m <module>[/<mainclass>] [args...]
       java [options] --module <module>[/<mainclass>] [args...]
           (to execute the main class in a module)
   or  java [options] <sourcefile> [args]
           (to execute a single source-file program)
...
```

-----

*Picture of a cool ROCK:*
