### PR TITLE
fix: File permission error when runnig SpringBoot application in ubuntu/jre:17

### DIFF
--- a/demos/petclinic/Dockerfile
+++ b/demos/petclinic/Dockerfile
@@ -7,7 +7,7 @@ ARG UID=101
 ARG GROUP=app
 ARG GID=101
 
-FROM eclipse-temurin:17.0.14_7-jdk-jammy as builder
+FROM eclipse-temurin:17.0.14_7-jdk-jammy AS builder
 
 ENV PETCLINIC_TAG=${PETCLINIC_TAG:-spring-boot-3.0.6}
 ENV PETCLINIC_REPO=${PETCLINIC_REPO:-https://github.com/vpa1977/spring-petclinic}
@@ -28,10 +28,8 @@ USER $UID:$GID
 
 # copy petclinic sample
 COPY --chown=$UID:$GID --from=builder \
-    /spring-petclinic/target/spring-petclinic-3.0.6.jar /
+    /spring-petclinic/target/spring-petclinic-3.0.0-SNAPSHOT.jar /
 
 WORKDIR /
 
-ENTRYPOINT ["/opt/java/bin/java", \
-    "-jar", \
-    "spring-petclinic-3.0.6.jar" ]
+CMD ["-jar", "spring-petclinic-3.0.0-SNAPSHOT.jar" ]

--- a/demos/petclinic/README.md
+++ b/demos/petclinic/README.md
@@ -6,6 +6,6 @@ This Dockerfile runs the [Spring PetClinic](https://github.com/spring-projects/s
 
 Execute:
 
-`` docker build -t petclinic . && docker run -p 8080:8080 --tmpfs /tmp:exec petclinic ``
+`` docker build -t petclinic . && docker run -p 8080:8080 petclinic ``
 
 Give it a few minutes to build the sample application and then navigate to http://localhost:8080 to explore the demo.

--- a/jre/Dockerfile.22.04
+++ b/jre/Dockerfile.22.04
@@ -53,7 +53,7 @@ RUN mkdir -p /rootfs \
         zlib1g_libs \
         libgraphite2-3_libs \
         libglib2.0-0_core \
-        base-files_bin \
+        base-files_base \
         base-files_chisel
 RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
     && mkdir -p /rootfs/etc \

--- a/tests/petclinic-test/runtest
+++ b/tests/petclinic-test/runtest
@@ -30,7 +30,6 @@ git clone --branch ${PETCLINIC_TAG} ${PETCLINIC_REPO} || \
 
 # We should replace Temurin with our dev container
 DOCKER_OPTS="--rm  \
-    --tmpfs /tmp:exec \
     -u app \
     -v ${M2_CACHE}:${M2_CACHE} \
     -v ${TEST_DIR}:${TEST_DIR} \


### PR DESCRIPTION
Fixes # https://bugs.launchpad.net/ubuntu-docker-images/+bug/2100959

#### Changes proposed in this pull request:
 - update artifact jar file in petclinic demo
 - use base_files_base slice to create Linux directory structure.
 - remove --tmpfs option as it is no longer necessary


-----

*Picture of a cool ROCK:*